### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,9 @@ name: Python Package using Conda
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/app.py
+++ b/app.py
@@ -125,5 +125,7 @@ def mapper():
     return render_template('mapper.html')
 
 if __name__ == '__main__':
+    import os
     init_db()
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_ENV') == 'development'
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/olatunike/metadata_mapping/security/code-scanning/1](https://github.com/olatunike/metadata_mapping/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs basic CI tasks (checking out the repository, setting up Python, installing dependencies, linting, and testing), it only requires `contents: read` permissions. This ensures that the workflow has the least privilege necessary to operate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
